### PR TITLE
more numerical stability

### DIFF
--- a/DeepCCAModels.py
+++ b/DeepCCAModels.py
@@ -11,13 +11,15 @@ class MlpNet(nn.Module):
         layer_sizes = [input_size] + layer_sizes
         for l_id in range(len(layer_sizes) - 1):
             if l_id == len(layer_sizes) - 2:
-                layers.append(
+                layers.append(nn.Sequential(
+                    nn.BatchNorm1d(num_features=layer_sizes[l_id], affine=False),
                     nn.Linear(layer_sizes[l_id], layer_sizes[l_id + 1]),
-                )
+                ))
             else:
                 layers.append(nn.Sequential(
                     nn.Linear(layer_sizes[l_id], layer_sizes[l_id + 1]),
                     nn.Sigmoid(),
+                    nn.BatchNorm1d(num_features=layer_sizes[l_id + 1], affine=False),
                 ))
         self.layers = nn.ModuleList(layers)
 

--- a/objectives.py
+++ b/objectives.py
@@ -77,9 +77,10 @@ class cca_loss():
             # assert torch.isnan(corr).item() == 0
         else:
             # just the top self.outdim_size singular values are used
-            U, V = torch.symeig(torch.matmul(
-                Tval.t(), Tval), eigenvectors=True)
-            # U = U[torch.gt(U, eps).nonzero()[:, 0]]
+            trace_TT = torch.matmul(Tval.t(), Tval)
+            trace_TT = torch.add(trace_TT, torch.eye(trace_TT.shape[0])*r1) # regularization for more tability
+            U, V = torch.symeig(trace_TT, eigenvectors=True)
+            U = torch.where(U>eps, U, torch.ones(U.shape).double()*eps)
             U = U.topk(self.outdim_size)[0]
             corr = torch.sum(torch.sqrt(U))
         return -corr

--- a/objectives.py
+++ b/objectives.py
@@ -78,9 +78,9 @@ class cca_loss():
         else:
             # just the top self.outdim_size singular values are used
             trace_TT = torch.matmul(Tval.t(), Tval)
-            trace_TT = torch.add(trace_TT, torch.eye(trace_TT.shape[0])*r1) # regularization for more tability
+            trace_TT = torch.add(trace_TT, (torch.eye(trace_TT.shape[0])*r1).to(self.device)) # regularization for more tability
             U, V = torch.symeig(trace_TT, eigenvectors=True)
-            U = torch.where(U>eps, U, torch.ones(U.shape).double()*eps)
+            U = torch.where(U>eps, U, (torch.ones(U.shape).double()*eps).to(self.device))
             U = U.topk(self.outdim_size)[0]
             corr = torch.sum(torch.sqrt(U))
         return -corr


### PR DESCRIPTION
Hi, 
Duo to [1] Weiran Wang paper, using whitening in the last layer of NN, can help the correlation approximations become more accurate.
Moreover, Duo to the [2] paper, for regularizing the Correlation definition with `Trace(T'T)^(-1/2)`, there is a need for adding a quadratic penalty to it.

[1]: W. Wang, Stochastic Optimization for Deep CCA via Nonlinear Orthogonal Iterations
[2]: G. Andrew, Deep Canonical Correlation Analysis